### PR TITLE
Port to Qt WebEngine (fixes Windows build)

### DIFF
--- a/qolibri.pro
+++ b/qolibri.pro
@@ -33,6 +33,7 @@ HEADERS += \
            src/titlelabel.h \
            src/toolbar.h \
            src/treescrollpopup.h \
+           src/webpage.h \
            src/webview.h \
 
 SOURCES += \
@@ -69,6 +70,7 @@ SOURCES += \
            src/textcodec.cpp \
            src/toolbar.cpp \
            src/treescrollpopup.cpp \
+           src/webpage.cpp \
            src/webview.cpp \
 
 RESOURCES += qolibri.qrc
@@ -77,7 +79,7 @@ FORMS += src/optiondialog.ui
 
 lessThan(QT_MAJOR_VERSION, 5): error("Qt 5 or later required")
 
-QT += multimedia network webkit webkitwidgets widgets
+QT += multimedia network webengine webenginewidgets widgets
 
 TARGET = qolibri
 DESTDIR = .

--- a/qolibri.pro
+++ b/qolibri.pro
@@ -33,7 +33,7 @@ HEADERS += \
            src/titlelabel.h \
            src/toolbar.h \
            src/treescrollpopup.h \
-           src/webpage.h \
+           src/webview.h \
 
 SOURCES += \
            src/allpage.cpp \
@@ -69,7 +69,7 @@ SOURCES += \
            src/textcodec.cpp \
            src/toolbar.cpp \
            src/treescrollpopup.cpp \
-           src/webpage.cpp \
+           src/webview.cpp \
 
 RESOURCES += qolibri.qrc
 

--- a/src/bookview.cpp
+++ b/src/bookview.cpp
@@ -176,7 +176,7 @@ RET_SEARCH BookView::newPage(QWidget *parent, const Query& query, bool newTab,
     foreach(Book *book, query.method.group->bookList()) {
         if (book->bookType() == BookWeb &&
                 book->checkState() == Qt::Checked) {
-            WebView *wpage = new WebView(this, book->path(), query);
+            WebView *wpage = new WebView(this);
             connect(wpage, SIGNAL(loadFinished(bool)),
                     SLOT(webViewFinished(bool)));
             connect(wpage, SIGNAL(processRequested(QString, QStringList)),
@@ -192,6 +192,7 @@ RET_SEARCH BookView::newPage(QWidget *parent, const Query& query, bool newTab,
             if (!focus_page) {
                 focus_page = (QWidget *)wpage;
             }
+            wpage->load(book->path(), query);
         }
     }
     emit popupBrowserSet(popup_browser);
@@ -206,7 +207,7 @@ RET_SEARCH BookView::newPage(QWidget *parent, const Query& query, bool newTab,
 RET_SEARCH BookView::newWebPage(const QString &name, const QString &url,
                                 bool popup_browser)
 {
-    WebView *wpage = new WebView(this, url);
+    WebView *wpage = new WebView(this);
     connect(wpage, SIGNAL(loadFinished(bool)), SLOT(webViewFinished(bool)));
     connect(wpage, SIGNAL(processRequested(QString, QStringList)),
             SIGNAL(processRequested(QString, QStringList)));
@@ -217,6 +218,7 @@ RET_SEARCH BookView::newWebPage(const QString &name, const QString &url,
     wpage->setTabIndex(idx);
     wpage->setTabBar(tabBar());
     setCurrentWidget(wpage);
+    wpage->load(url);
     emit tabChanged(count());
 
     return NORMAL;

--- a/src/bookview.cpp
+++ b/src/bookview.cpp
@@ -24,7 +24,7 @@
 #include "menupage.h"
 #include "infopage.h"
 #include "searchpage.h"
-#include "webpage.h"
+#include "webview.h"
 
 #include <QContextMenuEvent>
 #include <QDesktopWidget>
@@ -176,7 +176,7 @@ RET_SEARCH BookView::newPage(QWidget *parent, const Query& query, bool newTab,
     foreach(Book *book, query.method.group->bookList()) {
         if (book->bookType() == BookWeb &&
                 book->checkState() == Qt::Checked) {
-            WebPage *wpage = new WebPage(this, book->path(), query);
+            WebView *wpage = new WebView(this, book->path(), query);
             connect(wpage, SIGNAL(loadFinished(bool)),
                     SLOT(webViewFinished(bool)));
             connect(wpage, SIGNAL(processRequested(QString, QStringList)),
@@ -206,7 +206,7 @@ RET_SEARCH BookView::newPage(QWidget *parent, const Query& query, bool newTab,
 RET_SEARCH BookView::newWebPage(const QString &name, const QString &url,
                                 bool popup_browser)
 {
-    WebPage *wpage = new WebPage(this, url);
+    WebView *wpage = new WebView(this, url);
     connect(wpage, SIGNAL(loadFinished(bool)), SLOT(webViewFinished(bool)));
     connect(wpage, SIGNAL(processRequested(QString, QStringList)),
             SIGNAL(processRequested(QString, QStringList)));
@@ -358,7 +358,7 @@ SearchMethod BookView::pageMethod(int index)
     if (oname == "dicpage"){
         return ((PageWidget*)w)->method();
     } else if (oname == "webpage") {
-        return ((WebPage*)w)->method();
+        return ((WebView*)w)->method();
     } else if (oname == "bookview") {
         BookView *v = (BookView*)widget(index);
         return v->currentPageMethod();
@@ -388,7 +388,7 @@ void BookView::zoomIn()
     if (w->objectName() == "dicpage") {
         ((PageWidget*)w)->zoomIn();
     }else{
-        ((WebPage*)w)->zoomIn();
+        ((WebView*)w)->zoomIn();
     }
 }
 
@@ -404,7 +404,7 @@ void BookView::zoomOut()
     if (w->objectName() == "dicpage") {
         ((PageWidget*)w)->zoomOut();
     }else{
-        ((WebPage*)w)->zoomOut();
+        ((WebView*)w)->zoomOut();
     }
 }
 
@@ -444,7 +444,7 @@ void BookView::stopAllLoading()
 {
     for(int i=0; i < count(); i++) {
         if (widget(i)->objectName() == "webpage") {
-            WebPage *w = (WebPage*)widget(i);
+            WebView *w = (WebView*)widget(i);
             w->stop();
         } else if (widget(i)->objectName() == "bookview") {
             BookView *w = (BookView*)widget(i);
@@ -457,7 +457,7 @@ bool BookView::checkLoaded() {
     bool all_loaded = true;
     for(int i=0; i < count(); i++) {
         if (widget(i)->objectName() == "webpage") {
-            WebPage *w = (WebPage*)widget(i);
+            WebView *w = (WebView*)widget(i);
             if (w->loading()) {
                 all_loaded = false;
                 break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -29,7 +29,7 @@
 #include "ssheetsetting.h"
 #include "configure.h"
 #include "optiondialog.h"
-#include "webpage.h"
+#include "webview.h"
 
 #include <QClipboard>
 #include <QCloseEvent>
@@ -599,7 +599,7 @@ void MainWindow::showTabInfo(int index)
         reloadAct->setEnabled(false);
         showStatus(i.text());
     } else if (t == BookWeb) {
-        WebPage *w = (WebPage*)(bookView->pageWidget(index));
+        WebView *w = (WebView*)(bookView->pageWidget(index));
         showStatus(w->url().toString());
         webBar->show();
         reloadAct->setEnabled(true);
@@ -1020,7 +1020,7 @@ void MainWindow::addMark()
         s.replace("&&", "&");
         groupDock->addMark(s, m);
     } else {
-        WebPage *w = (WebPage*)(bookView->currentPageWidget());
+        WebView *w = (WebView*)(bookView->currentPageWidget());
         groupDock->addMark(w->title(), w->url().toString());
 
 //        QTabWidget *v = bookView;
@@ -1332,7 +1332,7 @@ void MainWindow::aboutQolibri()
 
 void MainWindow::goPrev()
 {
-    WebPage *w = (WebPage*)bookView->currentPageWidget();
+    WebView *w = (WebView*)bookView->currentPageWidget();
     w->back();
     if (w->history()->canGoBack()) {
         goPrevAct->setEnabled(true);
@@ -1348,7 +1348,7 @@ void MainWindow::goPrev()
 
 void MainWindow::goNext()
 {
-    WebPage *w = (WebPage*)bookView->currentPageWidget();
+    WebView *w = (WebView*)bookView->currentPageWidget();
     w->forward();
     if (w->history()->canGoBack()) {
         goPrevAct->setEnabled(true);
@@ -1364,7 +1364,7 @@ void MainWindow::goNext()
 
 void MainWindow::reload()
 {
-    WebPage *w = (WebPage*)bookView->currentPageWidget();
+    WebView *w = (WebView*)bookView->currentPageWidget();
     w->reload();
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -41,7 +41,7 @@
 #include <QStatusBar>
 #include <QTimer>
 #include <QToolBar>
-#include <QWebHistory>
+#include <QWebEngineHistory>
 
 const char *Program = { "qolibri" };
 

--- a/src/webpage.cpp
+++ b/src/webpage.cpp
@@ -1,0 +1,81 @@
+#include "webpage.h"
+
+#include <QMenu>
+#include <QWebEngineContextMenuData>
+#include <QWebEngineHistory>
+
+WebPage::WebPage(QObject* parent)
+: QWebEnginePage(parent)
+, delegateLinks(false)
+{
+}
+
+bool WebPage::acceptNavigationRequest(const QUrl &url, NavigationType type, bool isMainFrame)
+{
+    Q_UNUSED(isMainFrame);
+    if (type == NavigationTypeLinkClicked && delegateLinks) {
+        emit linkClicked(url);
+        return false;
+    }
+    return true;
+}
+
+// Stripped-down version of QWebEnginePage::createStandardContextMenu to
+// have consistent menus across platforms and Qt versions and to only
+// offer options that are actually supported
+QMenu *WebPage::createContextMenu() const
+{
+    const QWebEngineContextMenuData &cmdata = contextMenuData();
+    if (!cmdata.isValid())
+        return 0;
+
+    QWidget *const view = this->view();
+    QMenu *const menu = new QMenu(view);
+
+    if (cmdata.selectedText().isEmpty()) {
+        QAction *action = new QAction(QIcon::fromTheme(QStringLiteral("go-previous")), tr("&Back"), menu);
+        connect(action, SIGNAL(triggered()), view, SLOT(back()));
+        action->setEnabled(history()->canGoBack());
+        menu->addAction(action);
+
+        action = new QAction(QIcon::fromTheme(QStringLiteral("go-next")), tr("&Forward"), menu);
+        connect(action, SIGNAL(triggered()), view, SLOT(forward()));
+        action->setEnabled(history()->canGoForward());
+        menu->addAction(action);
+
+        action = new QAction(QIcon::fromTheme(QStringLiteral("view-refresh")), tr("&Reload"), menu);
+        connect(action, SIGNAL(triggered()), view, SLOT(reload()));
+        menu->addAction(action);
+    } else {
+        menu->addAction(action(Copy));
+        menu->addAction(action(Unselect));
+    }
+
+    if (!cmdata.linkText().isEmpty()) {
+        menu->addAction(action(OpenLinkInNewWindow));
+        menu->addAction(action(CopyLinkToClipboard));
+    }
+
+    if (cmdata.mediaUrl().isValid()) {
+        switch (cmdata.mediaType()) {
+        case QWebEngineContextMenuData::MediaTypeImage:
+            menu->addAction(action(CopyImageUrlToClipboard));
+            menu->addAction(action(CopyImageToClipboard));
+            break;
+        case QWebEngineContextMenuData::MediaTypeAudio:
+        case QWebEngineContextMenuData::MediaTypeVideo:
+            menu->addAction(action(CopyMediaUrlToClipboard));
+            menu->addAction(action(ToggleMediaPlayPause));
+            menu->addAction(action(ToggleMediaLoop));
+            menu->addAction(action(ToggleMediaMute));
+            break;
+        default:
+            break;
+        }
+    } else if (cmdata.mediaType() == QWebEngineContextMenuData::MediaTypeCanvas) {
+        menu->addAction(action(CopyImageToClipboard));
+    }
+
+    menu->setAttribute(Qt::WA_DeleteOnClose, true);
+    return menu;
+}

--- a/src/webpage.h
+++ b/src/webpage.h
@@ -1,0 +1,20 @@
+#ifndef WEBPAGE_H
+#define WEBPAGE_H
+
+#include <QWebEnginePage>
+
+class WebPage : public QWebEnginePage
+{
+    Q_OBJECT
+public:
+    explicit WebPage(QObject* parent = 0);
+    bool acceptNavigationRequest(const QUrl &url, NavigationType type, bool isMainFrame);
+    QMenu *createContextMenu() const;
+    void setDelegateLinks(bool enable) { delegateLinks = enable; }
+signals:
+    void linkClicked(const QUrl &url);
+private:
+    bool delegateLinks;
+};
+
+#endif // WEBPAGE_H

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -1,4 +1,4 @@
-#include "webpage.h"
+#include "webview.h"
 #include "configure.h"
 
 #include <QAction>
@@ -6,7 +6,7 @@
 #include <QTabBar>
 #include <QTextCodec>
 
-WebPage::WebPage(QWidget *parent, const QString &url, const Query& query)
+WebView::WebView(QWidget *parent, const QString &url, const Query& query)
     : QWebView(parent), method_(query.method)
 {
     loading_ = true;
@@ -43,7 +43,7 @@ WebPage::WebPage(QWidget *parent, const QString &url, const Query& query)
     show();
 }
 
-WebPage::WebPage(QWidget *parent, const QString &url)
+WebView::WebView(QWidget *parent, const QString &url)
     : QWebView(parent)
 {
     loading_ = true;
@@ -71,12 +71,12 @@ WebPage::WebPage(QWidget *parent, const QString &url)
 
     show();
 }
-void WebPage::openNewWin()
+void WebView::openNewWin()
 {
     emit processRequested(CONF->browserProcess, QStringList(hoveredLink));
 }
 
-void WebPage::copyHoveredLink(const QString &link, const QString&,
+void WebView::copyHoveredLink(const QString &link, const QString&,
                               const QString&)
 {
     if (!link.isEmpty()) {
@@ -84,7 +84,7 @@ void WebPage::copyHoveredLink(const QString &link, const QString&,
     }
 }
 
-void WebPage::contextMenuEvent(QContextMenuEvent* event)
+void WebView::contextMenuEvent(QContextMenuEvent* event)
 {
     QWebView::contextMenuEvent(event);
     //QMenu *menu = createStandardContextMenu();
@@ -93,7 +93,7 @@ void WebPage::contextMenuEvent(QContextMenuEvent* event)
 
 }
 
-QByteArray WebPage::encString(const QString &url)
+QByteArray WebView::encString(const QString &url)
 {
     if (!url.contains(QRegExp("\\{.*\\}"))) {
         return QByteArray();
@@ -104,7 +104,7 @@ QByteArray WebPage::encString(const QString &url)
     }
 }
 
-QString WebPage::setSearchString(const QString &url, const QByteArray &enc,
+QString WebView::setSearchString(const QString &url, const QByteArray &enc,
                                  const QString &query)
 {
     QByteArray bstr;
@@ -126,7 +126,7 @@ QString WebPage::setSearchString(const QString &url, const QByteArray &enc,
     }
     return ustr;
 }
-QString WebPage::directionString(const QString &url)
+QString WebView::directionString(const QString &url)
 {
     if (!url.contains(QRegExp("\\[.*\\]"))) {
         return QString();
@@ -136,7 +136,7 @@ QString WebPage::directionString(const QString &url)
         return w2.trimmed();
     }
 }
-QString WebPage::setDirectionString(const QString &url, const QString &dstr,
+QString WebView::setDirectionString(const QString &url, const QString &dstr,
                                     SearchDirection &direc)
 {
 
@@ -182,7 +182,7 @@ QString WebPage::setDirectionString(const QString &url, const QString &dstr,
 
 }
 
-void WebPage::progressStart()
+void WebView::progressStart()
 {
     loading_ = true;
     if (tabBar_) tabBar_->setTabIcon(tabIndex_, QIcon(":/images/web2.png"));
@@ -190,7 +190,7 @@ void WebPage::progressStart()
     progressCount_ = 0;
 }
 
-void WebPage::progress(int)
+void WebView::progress(int)
 {
     if (!tabBar_) return;
     if (progressCount_ == 0)  {
@@ -202,13 +202,13 @@ void WebPage::progress(int)
     }
 }
 
-void WebPage::progressFinished(bool)
+void WebView::progressFinished(bool)
 {
     loading_ = false;
     if (tabBar_) tabBar_->setTabIcon(tabIndex_, QIcon(":/images/web1.png"));
 }
 
-void WebPage::openLink(const QUrl &url)
+void WebView::openLink(const QUrl &url)
 {
     if (!popupBrowser_) {
         QUrl u = QUrl::fromEncoded(url.toEncoded(), QUrl::TolerantMode);
@@ -221,7 +221,7 @@ void WebPage::openLink(const QUrl &url)
 
 }
 
-void WebPage::changeFont(const QFont &font)
+void WebView::changeFont(const QFont &font)
 {
 
     qDebug() << "WebPage::changeFont" << font.family();
@@ -229,7 +229,7 @@ void WebPage::changeFont(const QFont &font)
 
 }
 
-void WebPage::zoomIn()
+void WebView::zoomIn()
 {
     QWebSettings *s = settings();
     int dsz = s->fontSize(QWebSettings::DefaultFontSize);
@@ -239,7 +239,7 @@ void WebPage::zoomIn()
     reload();
 }
 
-void WebPage::zoomOut()
+void WebView::zoomOut()
 {
     QWebSettings *s = settings();
     int dsz = s->fontSize(QWebSettings::DefaultFontSize);
@@ -249,7 +249,7 @@ void WebPage::zoomOut()
     reload();
 }
 
-void WebPage::setPopupBrowser(bool popup)
+void WebView::setPopupBrowser(bool popup)
 {
     popupBrowser_ = popup;
 }

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -182,6 +182,15 @@ QString WebView::setDirectionString(const QString &url, const QString &dstr,
 
 }
 
+void WebView::changeFontSize(int delta)
+{
+    QWebSettings *s = settings();
+    int dsz = s->fontSize(QWebSettings::DefaultFontSize);
+    int fsz = s->fontSize(QWebSettings::DefaultFixedFontSize);
+    s->setFontSize(QWebSettings::DefaultFontSize, dsz + delta);
+    s->setFontSize(QWebSettings::DefaultFixedFontSize, fsz + delta);
+}
+
 void WebView::progressStart()
 {
     loading_ = true;
@@ -231,22 +240,12 @@ void WebView::changeFont(const QFont &font)
 
 void WebView::zoomIn()
 {
-    QWebSettings *s = settings();
-    int dsz = s->fontSize(QWebSettings::DefaultFontSize);
-    int fsz = s->fontSize(QWebSettings::DefaultFixedFontSize);
-    s->setFontSize(QWebSettings::DefaultFontSize, dsz + 1);
-    s->setFontSize(QWebSettings::DefaultFixedFontSize, fsz + 1);
-    reload();
+    changeFontSize(1);
 }
 
 void WebView::zoomOut()
 {
-    QWebSettings *s = settings();
-    int dsz = s->fontSize(QWebSettings::DefaultFontSize);
-    int fsz = s->fontSize(QWebSettings::DefaultFixedFontSize);
-    s->setFontSize(QWebSettings::DefaultFontSize, dsz - 1);
-    s->setFontSize(QWebSettings::DefaultFixedFontSize, fsz - 1);
-    reload();
+    changeFontSize(-1);
 }
 
 void WebView::setPopupBrowser(bool popup)

--- a/src/webview.h
+++ b/src/webview.h
@@ -12,13 +12,14 @@ class WebView : public QWebView
 {
     Q_OBJECT
 public:
-    WebView(QWidget *parent, const QString &url, const Query& query);
-    WebView(QWidget *parent, const QString &url);
+    explicit WebView(QWidget *parent = 0);
     void zoomIn();
     void zoomOut();
     void setTabIndex(int index) { tabIndex_ = index; }
     void setTabBar(QTabBar *bar) { tabBar_ = bar; }
     SearchMethod method() { return method_; }
+    using QWebView::load;
+    void load(const QString &url, const Query &query);
     bool loading() { return loading_; }
 
 protected:

--- a/src/webview.h
+++ b/src/webview.h
@@ -1,5 +1,5 @@
-#ifndef WEBPAGE_H
-#define WEBPAGE_H
+#ifndef WEBVIEW_H
+#define WEBVIEW_H
 
 #include "method.h"
 
@@ -8,12 +8,12 @@
 struct QTabBar;
 struct Query;
 
-class WebPage : public QWebView
+class WebView : public QWebView
 {
     Q_OBJECT
 public:
-    WebPage(QWidget *parent, const QString &url, const Query& query);
-    WebPage(QWidget *parent, const QString &url);
+    WebView(QWidget *parent, const QString &url, const Query& query);
+    WebView(QWidget *parent, const QString &url);
     void zoomIn();
     void zoomOut();
     void setTabIndex(int index) { tabIndex_ = index; }
@@ -55,4 +55,4 @@ private:
     QTabBar *tabBar_;
 };
 
-#endif // WEBPAGE_H
+#endif // WEBVIEW_H

--- a/src/webview.h
+++ b/src/webview.h
@@ -45,7 +45,7 @@ private:
     QString directionString(const QString &url);
     QString setDirectionString(const QString &url, const QString &dstr,
                                SearchDirection &direc);
-
+    void changeFontSize(int delta);
     QString hoveredLink;
     bool loading_;
     bool popupBrowser_;

--- a/src/webview.h
+++ b/src/webview.h
@@ -3,12 +3,12 @@
 
 #include "method.h"
 
-#include <QWebView>
+#include <QWebEngineView>
 
 struct QTabBar;
 struct Query;
 
-class WebView : public QWebView
+class WebView : public QWebEngineView
 {
     Q_OBJECT
 public:
@@ -18,7 +18,7 @@ public:
     void setTabIndex(int index) { tabIndex_ = index; }
     void setTabBar(QTabBar *bar) { tabBar_ = bar; }
     SearchMethod method() { return method_; }
-    using QWebView::load;
+    using QWebEngineView::load;
     void load(const QString &url, const Query &query);
     bool loading() { return loading_; }
 
@@ -31,8 +31,7 @@ private slots:
     void progressFinished(bool ok);
     void openLink(const QUrl &url);
     void openNewWin();
-    void copyHoveredLink(const QString &link, const QString &title,
-                         const QString &text);
+    void copyHoveredLink(const QString &link);
     void changeFont(const QFont &font);
     void setPopupBrowser(bool);
 
@@ -49,7 +48,6 @@ private:
     void changeFontSize(int delta);
     QString hoveredLink;
     bool loading_;
-    bool popupBrowser_;
     SearchMethod method_;
     int progressCount_;
     int tabIndex_;


### PR DESCRIPTION
(Relates to #4)

For displaying web pages, qolibri was using the Qt WebKit library, which
was removed years ago with Qt 5.6. These days it's pretty much only
still available on GNU/Linux and the BSDs, where distros maintain it to
keep old apps working for now.

This PR ports to Qt WebKit's Chromium-based successor Qt WebEngine.

Among other things, this fixes Windows builds (only tested with official
prebuilt Qt 5.11.2 on Windows 10 x64 with VS2017 compiler):

![qolibri-win](https://user-images.githubusercontent.com/304760/47969151-96c2a680-e073-11e8-9793-9bec10bf6e7b.png)