### PR TITLE
README: qolibri is now packaged for openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ following operating systems:
 
 ### Linux distributions
 
-- [Arch Linux](https://www.archlinux.org/): AUR: https://aur.archlinux.org/packages/qolibri/
+- [Arch Linux](https://www.archlinux.org/): [AUR](https://aur.archlinux.org/packages/qolibri/)
 - [Void Linux](https://voidlinux.org/): `xbps-install qolibri`
+- [openSUSE](https://www.opensuse.org/): `zypper in qolibri` [OBS](https://software.opensuse.org/package/qolibri)
 
 ### Building from source
 


### PR DESCRIPTION
See <https://build.opensuse.org/request/show/882086>.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>